### PR TITLE
Make Thayam board responsive on mobile devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,21 +8,27 @@
 </head>
 <body>
     <div id="game-container">
-        <div id="player-1-home" class="player-home" data-player="1">Player 1</div>
-        <div id="player-2-home" class="player-home" data-player="2">Player 2</div>
-        <div id="player-3-home" class="player-home" data-player="3">Player 3</div>
-        <div id="player-4-home" class="player-home" data-player="4">Player 4</div>
+        <div id="board-area">
+            <div id="board"></div>
+        </div>
 
-        <div id="board"></div>
+        <div id="side-panel">
+            <div id="homes-container">
+                <div id="player-1-home" class="player-home" data-player="1">Player 1</div>
+                <div id="player-2-home" class="player-home" data-player="2">Player 2</div>
+                <div id="player-3-home" class="player-home" data-player="3">Player 3</div>
+                <div id="player-4-home" class="player-home" data-player="4">Player 4</div>
+            </div>
 
-        <div id="ui-panel">
-            <h2 id="player-turn">Player 1's Turn</h2>
-            <div id="message-area">Roll the dice to start!</div>
-            <div id="dice-container">
-                <div class="dice" id="dice1">0</div>
-                <div class="dice" id="dice2">0</div>
+            <div id="ui-panel">
+                <h2 id="player-turn">Player 1's Turn</h2>
+                <div id="message-area">Roll the dice to start!</div>
+                <div id="dice-container">
+                    <div class="dice" id="dice1">0</div>
+                    <div class="dice" id="dice2">0</div>
+                </div>
             </div>
-            </div>
+        </div>
     </div>
 
     <script src="script.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -1,8 +1,9 @@
 :root {
-    --board-size: 600px;
+    --board-min-size: 280px;
+    --board-max-size: 600px;
+    --board-size: clamp(var(--board-min-size), 80vw, var(--board-max-size));
     --cell-size: calc(var(--board-size) / 7);
     --coin-size: calc(var(--cell-size) * 0.45);
-    --home-size: calc(var(--cell-size) * 2.5);
     --border-color: #333;
 
     /* Player colors */
@@ -12,40 +13,45 @@
     --p4-color: #2ecc71; /* Green */
 }
 
+* {
+    box-sizing: border-box;
+}
+
 body {
     font-family: Arial, sans-serif;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    height: 100vh;
     background-color: #f0f0f0;
     margin: 0;
-    overflow: hidden; 
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    padding: 20px 16px;
 }
 
 #game-container {
-    display: grid;
-    grid-template-columns: var(--home-size) var(--board-size) var(--home-size);
-    grid-template-rows: var(--home-size) var(--board-size) var(--home-size);
+    width: min(100%, 1100px);
+    display: flex;
+    flex-direction: column;
     align-items: center;
-    justify-items: center;
+    gap: 24px;
+}
+
+#board-area {
+    width: var(--board-size);
+    height: var(--board-size);
 }
 
 #board {
-    grid-area: 2 / 2 / 3 / 3; 
-    width: var(--board-size);
-    height: var(--board-size);
+    width: 100%;
+    height: 100%;
     display: grid;
     grid-template-columns: repeat(7, 1fr);
     grid-template-rows: repeat(7, 1fr);
     border: 2px solid var(--border-color);
+    background-color: #fff;
 }
 
 .cell {
-    width: var(--cell-size);
-    height: var(--cell-size);
     border: 1px solid #ccc;
-    box-sizing: border-box;
     position: relative;
     display: flex;
     justify-content: center;
@@ -67,23 +73,43 @@ body {
 .safe-zone::after { transform: rotate(-45deg); }
 #cell-3-3 { background-color: #ffd700; }
 
-.player-home {
-    width: calc(var(--cell-size) * 2);
-    height: calc(var(--cell-size) * 2);
-    border: 2px dashed var(--border-color);
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 5px;
-    padding: 5px;
-    box-sizing: border-box;
-    align-content: center;
-    justify-items: center;
+#side-panel {
+    width: min(100%, var(--board-size));
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    align-items: stretch;
 }
 
-#player-1-home { grid-area: 3 / 2 / 4 / 3; border-color: var(--p1-color); }
-#player-2-home { grid-area: 2 / 3 / 3 / 4; border-color: var(--p2-color); }
-#player-3-home { grid-area: 1 / 2 / 2 / 3; border-color: var(--p3-color); }
-#player-4-home { grid-area: 2 / 1 / 3 / 2; border-color: var(--p4-color); }
+#homes-container {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 16px;
+    width: 100%;
+}
+
+.player-home {
+    position: relative;
+    min-height: calc(var(--cell-size) * 2.6);
+    border: 2px dashed var(--border-color);
+    border-radius: 12px;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    align-content: center;
+    justify-items: center;
+    padding: 12px;
+    background-color: #fff;
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: #555;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+#player-1-home { border-color: var(--p1-color); }
+#player-2-home { border-color: var(--p2-color); }
+#player-3-home { border-color: var(--p3-color); }
+#player-4-home { border-color: var(--p4-color); }
 
 /* Coins */
 .coin {
@@ -95,7 +121,7 @@ body {
     box-sizing: border-box;
     cursor: pointer;
     transition: transform 0.2s, top 0.2s, left 0.2s, right 0.2s, bottom 0.2s;
-    position: absolute; 
+    position: absolute;
 }
 
 .coin.movable:hover {
@@ -110,8 +136,7 @@ body {
 .coin[data-player="3"] { background-color: var(--p3-color); }
 .coin[data-player="4"] { background-color: var(--p4-color); }
 
-
-/* --- NEW: Default centering for coins in non-safe cells --- */
+/* --- Default centering for coins in non-safe cells --- */
 .coin.coin-center {
     top: 50%;
     left: 50%;
@@ -119,25 +144,45 @@ body {
 }
 
 /* --- Positioning for multiple coins in one SAFE cell --- */
-.coin.coin-pos-0 { top: 5%; left: 5%; } /* Player 1 */
-.coin.coin-pos-1 { top: 5%; right: 5%; } /* Player 2 */
-.coin.coin-pos-2 { bottom: 5%; left: 5%; } /* Player 3 */
-.coin.coin-pos-3 { bottom: 5%; right: 5%; } /* Player 4 */
-
+.coin.coin-pos-0 { top: 5%; left: 5%; }
+.coin.coin-pos-1 { top: 5%; right: 5%; }
+.coin.coin-pos-2 { bottom: 5%; left: 5%; }
+.coin.coin-pos-3 { bottom: 5%; right: 5%; }
 
 #ui-panel {
-    width: 200px;
+    width: 100%;
+    max-width: 420px;
+    margin: 0 auto;
     text-align: center;
     padding: 20px;
     background: #fff;
-    border-radius: 10px;
+    border-radius: 12px;
     box-shadow: 0 0 10px rgba(0,0,0,0.1);
-    transition: grid-area 0.5s ease-in-out;
 }
 
-#player-turn { margin-top: 0; font-size: 1.2em; }
+#player-turn { margin-top: 0; font-size: 1.3em; }
 #message-area { margin: 15px 0; min-height: 40px; color: #555; }
 #dice-container { display: flex; justify-content: center; gap: 10px; margin-bottom: 20px; }
-.dice { width: 50px; height: 50px; border: 2px solid var(--border-color); border-radius: 5px; display: flex; justify-content: center; align-items: center; font-size: 2em; font-weight: bold; }
+.dice { width: 60px; height: 60px; border: 2px solid var(--border-color); border-radius: 8px; display: flex; justify-content: center; align-items: center; font-size: 2em; font-weight: bold; background-color: #fafafa; }
 #roll-dice-btn { padding: 10px 20px; font-size: 1em; border-radius: 5px; border: none; background-color: #27ae60; color: white; cursor: pointer; transition: background-color 0.2s; }
 #roll-dice-btn:disabled { background-color: #95a5a6; cursor: not-allowed; }
+
+@media (min-width: 900px) {
+    :root {
+        --board-size: clamp(400px, 55vh, 640px);
+    }
+
+    body {
+        align-items: center;
+    }
+
+    #game-container {
+        flex-direction: row;
+        align-items: flex-start;
+        gap: 40px;
+    }
+
+    #side-panel {
+        width: min(100%, 420px);
+    }
+}


### PR DESCRIPTION
## Summary
- restructure the page layout so the board sits in a dedicated top area with player homes and controls grouped below
- replace the fixed grid sizing with responsive flex/grid styling that scales the board and panels across device widths
- polish supporting styles for dice and homes while keeping existing game logic intact

## Testing
- Manual verification in a mobile viewport (Playwright screenshot)


------
https://chatgpt.com/codex/tasks/task_e_68e29c17cf448333b271eccb827f047b